### PR TITLE
🎨 Palette: Add skip link and focus styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-20 - Navigation Embedded in Content
+**Learning:** The site's navigation is embedded within `index.md` (content) rather than `_layouts/default.html` (layout). This complicates global accessibility features like "Skip to content" because the "content" wrapper in the layout includes the navigation itself.
+**Action:** When implementing skip links, target the specific section *after* the navigation block within the content file, rather than the generic content container in the layout.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,6 +55,7 @@
 </head>
 
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="wrapper">
         <div class="main-content">
             {{ content }}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -9,6 +9,30 @@
   box-sizing: border-box;
 }
 
+/* Accessibility Styles */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  padding: 10px 20px;
+  background: var(--primary-color);
+  color: #fff;
+  z-index: 10000;
+  text-decoration: none;
+  border-radius: 0 0 8px 0;
+  transition: top 0.3s ease;
+  font-weight: 600;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
+:focus-visible {
+  outline: 3px solid var(--primary-color);
+  outline-offset: 3px;
+}
+
 /* Light/Dark mode variables */
 :root {
   --primary-color: #0366d6;

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ keywords: "software engineer, data engineering, robotics, Apache Spark, AWS, mac
 </div>
 
 <!-- Enhanced Hero Section -->
-<div class="hero-section">
+<div id="main-content" class="hero-section" tabindex="-1">
   <div class="hero-content">
     <div class="hero-left">
       <div class="hero-profile">


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link and global `:focus-visible` styles.
🎯 Why: To improve accessibility for keyboard and screen reader users, allowing them to bypass navigation and see focus indicators clearly.
📸 Before/After: (Focus styles were missing, now present)
♿ Accessibility:
- Added skip link to `_layouts/default.html` targeting `#main-content`.
- Added `id="main-content"` to the hero section in `index.md`.
- Added visible outline for keyboard focus in `assets/css/style.scss`.

---
*PR created automatically by Jules for task [7515408590434388123](https://jules.google.com/task/7515408590434388123) started by @georgeerol*