### PR TITLE
🎨 Palette: Add Skip to Content Link and Focus Styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-26 - Skip Link Implementation in Single-Page Jekyll Layouts
+**Learning:** In Jekyll sites where navigation is embedded in the content file (`index.md`) rather than the layout, standard skip links pointing to `main` tags might fail if the `main` tag wraps the content including the navigation.
+**Action:** Always verify the "main content" start point within the rendered HTML structure. If navigation is part of the content body, manually add an ID (e.g., `#main-content`) to the first content section (like a hero section) to ensure the skip link effectively bypasses the navigation.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,6 +55,7 @@
 </head>
 
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="wrapper">
         <div class="main-content">
             {{ content }}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -74,6 +74,33 @@ body {
   transition: background 0.3s ease, color 0.3s ease;
 }
 
+/* Accessibility */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  padding: 10px 20px;
+  background: var(--primary-color);
+  color: white;
+  z-index: 1000;
+  text-decoration: none;
+  border-radius: 0 0 8px 0;
+  transition: top 0.3s ease;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
+:focus-visible {
+  outline: 3px solid var(--primary-color);
+  outline-offset: 3px;
+}
+
+.btn:focus-visible {
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.5);
+}
+
 .wrapper {
   max-width: none !important;
   margin: 0 !important;

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ keywords: "software engineer, data engineering, robotics, Apache Spark, AWS, mac
 </div>
 
 <!-- Enhanced Hero Section -->
-<div class="hero-section">
+<div class="hero-section" id="main-content">
   <div class="hero-content">
     <div class="hero-left">
       <div class="hero-profile">


### PR DESCRIPTION
*   💡 What: Added a "Skip to main content" link and improved keyboard focus visibility.
*   🎯 Why: Improves accessibility for keyboard and screen reader users, allowing them to bypass navigation.
*   📸 Before/After: Added hidden skip link that appears on focus. Added global `:focus-visible` styles.
*   ♿ Accessibility: Meets WCAG criteria for bypass blocks and focus visible.

---
*PR created automatically by Jules for task [4185781079885925484](https://jules.google.com/task/4185781079885925484) started by @georgeerol*