### PR TITLE
🎨 Palette: Add accessible skip-to-content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2026-01-20 - Skip Link Implementation in Hybrid Layout
+**Learning:** The site's navigation is embedded directly in the content file (`index.md`) rather than the layout file (`_layouts/default.html`). This creates a challenge for "Skip to Content" links because the target ID must be placed within the content file, not the layout.
+**Action:** When implementing bypass blocks in Jekyll sites with mixed content/layout responsibility, verify where the navigation lives before placing the target anchor.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,6 +55,7 @@
 </head>
 
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="wrapper">
         <div class="main-content">
             {{ content }}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -9,6 +9,27 @@
   box-sizing: border-box;
 }
 
+/* Skip to content link for accessibility */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  padding: 10px 20px;
+  background: var(--primary-color);
+  color: white;
+  z-index: 10000;
+  text-decoration: none;
+  border-radius: 0 0 5px 0;
+  transition: top 0.3s;
+  font-weight: 600;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 2px solid white;
+  outline-offset: -2px;
+}
+
 /* Light/Dark mode variables */
 :root {
   --primary-color: #0366d6;

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 // Smooth scrolling for navigation links
-document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+document.querySelectorAll('a[href^="#"]:not(.skip-link)').forEach(anchor => {
     anchor.addEventListener('click', function (e) {
         e.preventDefault();
         const target = document.querySelector(this.getAttribute('href'));

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ keywords: "software engineer, data engineering, robotics, Apache Spark, AWS, mac
 </div>
 
 <!-- Enhanced Hero Section -->
-<div class="hero-section">
+<div id="main-content" class="hero-section">
   <div class="hero-content">
     <div class="hero-left">
       <div class="hero-profile">


### PR DESCRIPTION
- Added skip link to `_layouts/default.html`.
- Added `id="main-content"` to `index.md` hero section.
- Added visible-on-focus styles to `assets/css/style.scss`.
- Excluded skip link from JS smooth scrolling in `assets/js/portfolio.js` to ensure proper focus management.
- Documented learnings in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [8710223580588549966](https://jules.google.com/task/8710223580588549966) started by @georgeerol*