### PR TITLE
🎨 Palette: Add Back to Top button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-31 - [Fixed Positioning Conflicts]
+**Learning:** The "AI Assistant" component uses a fixed position in the bottom-right corner (`bottom: 30px`, `right: 30px`), creating a "dead zone" for other floating elements like "Back to Top" buttons.
+**Action:** Always check `assets/css/ai-assistant.css` or visually inspect the bottom-right quadrant before adding new fixed elements. Stack elements vertically (e.g., `bottom: 110px`) to preserve accessibility for both controls.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -61,6 +61,11 @@
         </div>
     </div>
     
+    <!-- Back to Top Button -->
+    <button id="back-to-top" class="back-to-top" aria-label="Back to top">
+        <i data-lucide="arrow-up"></i>
+    </button>
+
     <!-- Custom JavaScript -->
     <script src="{{ '/assets/js/portfolio.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/ai-assistant.js' | relative_url }}"></script>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1855,3 +1855,52 @@ body {
   z-index: 60 !important;
   position: relative !important;
 }
+
+/* Back to Top Button */
+.back-to-top {
+  position: fixed;
+  bottom: 110px;
+  right: 30px;
+  background: var(--primary-color);
+  color: white;
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(20px);
+  transition: all 0.3s ease;
+  z-index: 999;
+}
+
+.back-to-top.visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.back-to-top:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 6px 16px rgba(0,0,0,0.2);
+}
+
+.back-to-top:focus-visible {
+  outline: 3px solid var(--accent-color);
+  outline-offset: 3px;
+}
+
+/* Adjust for mobile */
+@media (max-width: 768px) {
+  .back-to-top {
+    bottom: 100px;
+    right: 20px;
+    width: 45px;
+    height: 45px;
+  }
+}

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -543,3 +543,25 @@ document.addEventListener('DOMContentLoaded', function() {
         initPixelCharacterGame();
     }, 500);
 });
+
+// Back to Top Button Logic
+document.addEventListener('DOMContentLoaded', function() {
+    const backToTopBtn = document.getElementById('back-to-top');
+
+    if (backToTopBtn) {
+        window.addEventListener('scroll', () => {
+            if (window.scrollY > 300) {
+                backToTopBtn.classList.add('visible');
+            } else {
+                backToTopBtn.classList.remove('visible');
+            }
+        });
+
+        backToTopBtn.addEventListener('click', () => {
+            window.scrollTo({
+                top: 0,
+                behavior: 'smooth'
+            });
+        });
+    }
+});


### PR DESCRIPTION
🎨 **Palette Check-in**

**What:** Added a "Back to Top" button that appears when scrolling down.
**Why:** The portfolio page is quite long (Client Work, Robotics, Data Pipeline, etc.). Users need an easy way to return to the navigation/intro without manual scrolling.
**Accessibility:**
- Added `aria-label="Back to top"` for screen readers.
- Added `:focus-visible` styles for keyboard navigation.
- Ensured it doesn't overlap with the existing "AI Assistant" button (stacked vertically).
**Visuals:**
- Matches the primary theme color.
- Smooth fade-in/out transition.
- Hover effect with slight lift and shadow.

**Verification:**
- Verified using Playwright (simulating scroll and click).
- Confirmed correct positioning relative to the AI Assistant.

---
*PR created automatically by Jules for task [17488049664499101382](https://jules.google.com/task/17488049664499101382) started by @georgeerol*