### PR TITLE
🎨 Palette: Add "Skip to main content" link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Accessibility: Skip to Content
+**Learning:** Static sites with sticky headers and JS-based smooth scrolling need careful handling for "Skip to Content" links. The JS smooth scrolling must explicitly exclude the skip link to allow the browser's default focus behavior (instant jump), otherwise the focus management fails.
+**Action:** Always verify skip links with smooth scrolling disabled or excluded, and ensure the target ID exists on the main content container.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,6 +55,7 @@
 </head>
 
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="wrapper">
         <div class="main-content">
             {{ content }}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1855,3 +1855,23 @@ body {
   z-index: 60 !important;
   position: relative !important;
 }
+
+/* Skip Link Styles (Accessibility) */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  background: var(--primary-color);
+  color: white;
+  padding: 8px 16px;
+  z-index: 9999;
+  text-decoration: none;
+  font-weight: bold;
+  transition: top 0.3s;
+  border-radius: 0 0 4px 0;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 3px solid var(--accent-color);
+}

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 // Smooth scrolling for navigation links
-document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+document.querySelectorAll('a[href^="#"]:not(.skip-link)').forEach(anchor => {
     anchor.addEventListener('click', function (e) {
         e.preventDefault();
         const target = document.querySelector(this.getAttribute('href'));

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ keywords: "software engineer, data engineering, robotics, Apache Spark, AWS, mac
 </div>
 
 <!-- Enhanced Hero Section -->
-<div class="hero-section">
+<div class="hero-section" id="main-content">
   <div class="hero-content">
     <div class="hero-left">
       <div class="hero-profile">


### PR DESCRIPTION
💡 What: Added a hidden "Skip to main content" link that becomes visible on focus.
🎯 Why: Allows keyboard and screen reader users to bypass the navigation menu and jump directly to the main content (Hero section).
♿ Accessibility:
- Added `href="#main-content"` anchor.
- Added `id="main-content"` target to Hero section.
- Added `.skip-link` CSS for accessible hiding/showing.
- Excluded `.skip-link` from JS smooth scrolling to ensure proper focus management.

---
*PR created automatically by Jules for task [12749131083744392198](https://jules.google.com/task/12749131083744392198) started by @georgeerol*