### PR TITLE
🎨 Palette: Add Skip to Content and Focus Styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,11 @@
+# Palette's Journal
+
+## Critical UX/Accessibility Learnings only.
+
+Format: `## YYYY-MM-DD - [Title]
+**Learning:** [UX/a11y insight]
+**Action:** [How to apply next time]`
+
+## 2026-01-26 - Keyboard Accessibility in SPA-like Static Sites
+**Learning:** In a Jekyll site where the navigation is embedded in the content file (`index.md`) rather than the layout, a standard "Skip to content" link pointing to the layout's content wrapper will fail to skip the navigation. The target ID must be placed on the first focusable element *after* the embedded navigation within the content file itself.
+**Action:** When adding skip links to static sites, always verify where the navigation lives in the DOM structure relative to the content injection point (`{{ content }}`).

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,6 +55,7 @@
 </head>
 
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="wrapper">
         <div class="main-content">
             {{ content }}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1855,3 +1855,33 @@ body {
   z-index: 60 !important;
   position: relative !important;
 }
+
+/* Accessibility Improvements */
+:focus-visible {
+  outline: 3px solid var(--primary-color);
+  outline-offset: 3px;
+}
+
+.btn:focus-visible {
+  box-shadow: 0 0 0 3px rgba(3, 102, 214, 0.4);
+}
+
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  padding: 10px 20px;
+  background: var(--primary-color);
+  color: white;
+  z-index: 1000;
+  text-decoration: none;
+  font-weight: bold;
+  border-bottom-right-radius: 8px;
+  transition: top 0.2s ease;
+}
+
+.skip-link:focus {
+  top: 0;
+  outline: 3px solid var(--accent-color);
+  outline-offset: -3px;
+}

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ keywords: "software engineer, data engineering, robotics, Apache Spark, AWS, mac
 </div>
 
 <!-- Enhanced Hero Section -->
-<div class="hero-section">
+<div class="hero-section" id="main-content">
   <div class="hero-content">
     <div class="hero-left">
       <div class="hero-profile">


### PR DESCRIPTION
💡 What: Added a "Skip to main content" link and global `:focus-visible` styles.
🎯 Why: To improve keyboard accessibility and compliance with WCAG standards. The skip link allows keyboard users to bypass the navigation menu, and the focus styles ensure the current focus is always visible.
📸 Before/After: (Skip link was missing; now appears on top left when focused. Focus outlines are now prominent blue/green).
♿ Accessibility:
- Added `.skip-link` class and HTML anchor.
- Added `id="main-content"` to the hero section (first content after nav).
- Added `:focus-visible` outline styles.

---
*PR created automatically by Jules for task [5296780211878475106](https://jules.google.com/task/5296780211878475106) started by @georgeerol*