### PR TITLE
🎨 Palette: Add skip link and focus-visible styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-01-20 - Accessible Skip Links
+**Learning:** Skip links work best when the JS smooth scrolling logic explicitly excludes them (`:not(.skip-link)`), preserving the browser's native focus jump behavior which is critical for keyboard navigation.
+**Action:** Always verify if smooth scrolling scripts intercept anchor links and exempt accessibility shortcuts.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,6 +55,7 @@
 </head>
 
 <body>
+    <a href="#main-content" class="skip-link">Skip to main content</a>
     <div class="wrapper">
         <div class="main-content">
             {{ content }}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1855,3 +1855,27 @@ body {
   z-index: 60 !important;
   position: relative !important;
 }
+
+/* Accessibility Improvements */
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  padding: 10px 20px;
+  background: var(--primary-color);
+  color: white;
+  z-index: 1000;
+  text-decoration: none;
+  font-weight: bold;
+  border-bottom-right-radius: 8px;
+  transition: top 0.3s;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
+:focus-visible {
+  outline: 3px solid var(--primary-color);
+  outline-offset: 3px;
+}

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 // Smooth scrolling for navigation links
-document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+document.querySelectorAll('a[href^="#"]:not(.skip-link)').forEach(anchor => {
     anchor.addEventListener('click', function (e) {
         e.preventDefault();
         const target = document.querySelector(this.getAttribute('href'));

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ keywords: "software engineer, data engineering, robotics, Apache Spark, AWS, mac
 </div>
 
 <!-- Enhanced Hero Section -->
-<div class="hero-section">
+<div class="hero-section" id="main-content" tabindex="-1">
   <div class="hero-content">
     <div class="hero-left">
       <div class="hero-profile">


### PR DESCRIPTION
This PR introduces key accessibility improvements:
1.  **Skip to main content link**: Allows keyboard users to bypass the navigation menu and jump directly to the content.
    -   Implemented in `_layouts/default.html`.
    -   Target `div.hero-section` in `index.md` assigned `id="main-content"` and `tabindex="-1"`.
2.  **Focus visible styles**: Adds a clear outline to focused elements when using keyboard navigation.
    -   Implemented in `assets/css/style.scss`.
3.  **Smooth scroll exclusion**: Updates `assets/js/portfolio.js` to prevent the custom smooth scroll script from intercepting the skip link, ensuring proper focus transfer.

Verification:
-   Verified using a Playwright script that the skip link is the first focusable element and receives focus when Tab is pressed.
-   Verified that the skip link becomes visible when focused.

---
*PR created automatically by Jules for task [355759457065026756](https://jules.google.com/task/355759457065026756) started by @georgeerol*