### PR TITLE
🎨 Palette: Add focus visible styles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-04 - Keyboard Navigation Blind Spots
+**Learning:** Many static sites rely solely on browser defaults for focus states, which are often inconsistent or invisible, especially on custom buttons. This creates a significant barrier for keyboard users who cannot easily see where they are on the page.
+**Action:** Always include explicit `:focus-visible` styles in the global CSS reset or base styles. Using `outline-offset` improves visibility against different background colors.

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1855,3 +1855,9 @@ body {
   z-index: 60 !important;
   position: relative !important;
 }
+
+/* Focus styles for accessibility */
+:focus-visible {
+  outline: 3px solid var(--primary-color);
+  outline-offset: 3px;
+}


### PR DESCRIPTION
🎨 Palette: Added focus visible styles for keyboard accessibility

💡 What: Added global `:focus-visible` styles to `assets/css/style.scss`.
🎯 Why: To improve keyboard navigation visibility for users who rely on keyboard or assistive technologies.
📸 Before/After: (Verified via screenshot in `verification/focus_screenshot.png`, not included in repo)
♿ Accessibility: Ensures interactive elements have a clear visual indicator when focused via keyboard.

---
*PR created automatically by Jules for task [17242515786669972870](https://jules.google.com/task/17242515786669972870) started by @georgeerol*